### PR TITLE
Ensure flush sends no-cache headers

### DIFF
--- a/opcache.php
+++ b/opcache.php
@@ -6,6 +6,9 @@ if (isset($_GET['invalidate'])) {
 
 if (isset($_GET['reset'])) {
     opcache_reset();
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Cache-Control: post-check=0, pre-check=0', false);
+    header('Pragma: no-cache');
     header('Location: ' . $_SERVER['PHP_SELF'].'#scripts');
 }
 


### PR DESCRIPTION
Otherwise browsers may cache the `?reset` response and do nothing.